### PR TITLE
Exclude tests folder from package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
-include requirements.txt
 include README.md
 include LICENSE.txt
+prune tests*

--- a/setup.py
+++ b/setup.py
@@ -1,30 +1,30 @@
-from setuptools import setup, find_packages
 from pathlib import Path
+
+from setuptools import find_packages, setup
 
 
 def read_file(filename: str) -> str:
-    with open(Path(__file__).parent / filename, mode='r', encoding='utf-8') as f:
+    with open(Path(__file__).parent / filename, mode="r", encoding="utf-8") as f:
         return f.read()
 
 
-PACKAGE_NAME = 'convkan'
+PACKAGE_NAME = "convkan"
 
-long_description = read_file('README.md')
-long_description_content_type = 'text/markdown'
+long_description = read_file("README.md")
+long_description_content_type = "text/markdown"
 
-python_requires = '>=3.8'
-install_requires = read_file('requirements.txt').splitlines()
+python_requires = ">=3.8"
 
 setup(
     name=PACKAGE_NAME,
-    packages=find_packages(),
-    version='0.0.1.2',
-    author='Vladimir Starostin',
-    author_email='vladimir.starostin@uni-tuebingen.de',
-    license='MIT',
-    description='Convolutional KAN layer',
+    packages=find_packages(exclude=("tests",)),
+    version="0.0.1.3",
+    author="Vladimir Starostin",
+    author_email="vladimir.starostin@uni-tuebingen.de",
+    license="MIT",
+    description="Convolutional KAN layer",
     long_description=long_description,
     long_description_content_type=long_description_content_type,
     python_requires=python_requires,
-    install_requires=install_requires,
+    install_requires=["torch>=2.3.0", "torchvision>=0.18.0", "tqdm>=4.66.2"],
 )


### PR DESCRIPTION
We're importing convkan and it packages the tests folder in the package. This just makes changes to remove the tests folder from the package. Otherwise, the tests end up as 'tests' in the venv namespace and can conflict with local folders named tests and namespaced in other projects. 